### PR TITLE
CC-11 # more accurate ContentType detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ interface UploadOptions {
   filePaths?: String[], // defaults to glob(['**/*'])
   fs? : Object, // defaults to require('fs')
   prune = false : Boolean,
-  s3: AWS.S3
+  s3: AWS.S3,
+  skip = true : Boolean
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ upload (options: UploadOptions) => Task
 ```
 interface Task extends EventEmitter {
   filePaths: String[],
+  files: Map,
+  objects: Map,
   promise: Promise
 }
 ```
@@ -85,8 +87,7 @@ task.on('error', (error, fileName) => {
 
 ## Roadmap
 
-- [ ] implement "dryRun" option
-- [ ] implement "prune" option
-- [ ] implement "fs" option
-- [ ] support S3 Buckets with more than 100 Objects
-- [ ] better detection for Content-Type header
+- [ ] "dryRun" option
+- [ ] "prune" option
+- [ ] "fs" option
+- [ ] support S3 Buckets with more than 1000 Objects

--- a/lib/maps.js
+++ b/lib/maps.js
@@ -4,6 +4,8 @@ const workerFarm = require('worker-farm');
 
 const workers = workerFarm(require.resolve('./utils/fs-map-child'));
 
+// fromS3Contents (contents: Object[]) => Promise<Map>
+// creates a Map by parsing the result of an S3 listObjects request
 function fromS3Contents (contents) {
   const map = new Map();
   contents.forEach((entry) => {
@@ -12,12 +14,15 @@ function fromS3Contents (contents) {
   return Promise.resolve(map);
 }
 
+// fromFiles (fs?: Object, cwd: String, filePaths: String[]) => Promise<Map>
+// creates a Map by scanning the local filesystem
 function fromFiles (fs, cwd, filePaths) {
   const map = new Map();
 
   return new Promise((resolve, reject) => {
     for (let f = 0; f < filePaths.length; f += 1) {
       let filePath = filePaths[f];
+      // sends one path at a time to the worker pool
       workers({ cwd, filePath }, (err, output) => {
         if (err) {
           reject(err);
@@ -27,7 +32,10 @@ function fromFiles (fs, cwd, filePaths) {
           output.LastModified = new Date(output.LastModified);
         }
         map.set(filePath, output);
+
+        // we can only tell we are finished by counting our results
         if (map.size >= filePaths.length) {
+          // looks like we're done
           resolve(map);
         }
       });
@@ -35,20 +43,25 @@ function fromFiles (fs, cwd, filePaths) {
   });
 }
 
+// trimQuotes (string: String) => String
 function trimQuotes (string) {
   return string.trim().replace(/"/g, '');
 }
 
+// isEqual (file: Object, object: Object) => Boolean
 function isEqual (file, object) {
   return file.Size === object.Size && trimQuotes(file.ETag) === trimQuotes(object.ETag);
 }
 
+// compare (files: Map, objects: Map, options: Object) => Object
+// creates a plan of what to do by comparing the local and remote Maps
 function compare (files, objects, options) {
   const deletes = [];
   const noops = [];
   const uploads = [];
   const skip = options.skip;
 
+  // compare local against remote, to find local files to upload
   for (let key of files.keys()) {
     let file = files.get(key);
     let object = objects.get(key);
@@ -59,6 +72,7 @@ function compare (files, objects, options) {
     }
   }
 
+  // compare remote against local, to find remote files to delete
   for (let key of objects.keys()) {
     if (!files.has(key)) {
       deletes.push(key);

--- a/lib/maps.js
+++ b/lib/maps.js
@@ -43,15 +43,16 @@ function isEqual (file, object) {
   return file.Size === object.Size && trimQuotes(file.ETag) === trimQuotes(object.ETag);
 }
 
-function compare (files, objects) {
+function compare (files, objects, options) {
   const deletes = [];
   const noops = [];
   const uploads = [];
+  const skip = options.skip;
 
   for (let key of files.keys()) {
     let file = files.get(key);
     let object = objects.get(key);
-    if (!object || !isEqual(file, object)) {
+    if (!object || !isEqual(file, object) || !skip) {
       uploads.push(key);
     } else {
       noops.push(key);

--- a/lib/upload-object.js
+++ b/lib/upload-object.js
@@ -7,9 +7,20 @@ function uploadObject (task, fileName) {
   const cwd = task.cwd;
   let stream = fs.createReadStream(path.join(cwd, fileName));
   task.emit('uploading', fileName);
+  let meta;
+
+  try {
+    meta = task.files.get(fileName);
+  } catch (err) {
+    const error = new Error('metadata for ' + fileName + ' unavailable');
+    task.emit('error', error, fileName);
+    return Promise.reject(error);
+  }
+
   return new Promise((resolve, reject) => {
     task.s3.upload({
       Body: stream,
+      ContentType: meta.ContentType,
       Key: fileName
     }, (err, data) => {
       if (err) {

--- a/lib/upload-object.js
+++ b/lib/upload-object.js
@@ -3,12 +3,14 @@
 const fs = require('fs');
 const path = require('path');
 
+// uploadObject (task: Task, fileName: String) => Promise
 function uploadObject (task, fileName) {
   const cwd = task.cwd;
   let stream = fs.createReadStream(path.join(cwd, fileName));
   task.emit('uploading', fileName);
-  let meta;
 
+  // lookup details in our local files Map
+  let meta;
   try {
     meta = task.files.get(fileName);
   } catch (err) {
@@ -17,6 +19,7 @@ function uploadObject (task, fileName) {
     return Promise.reject(error);
   }
 
+  // make request to AWS S3
   return new Promise((resolve, reject) => {
     task.s3.upload({
       Body: stream,
@@ -41,6 +44,8 @@ function uploadObject (task, fileName) {
 
 module.exports = {
   uploadObject,
+
+  // uploadObjects (task: Task, fileList: String[]) => Promise
   uploadObjects (task, fileList) {
     return Promise.all(fileList.map((fileName) => uploadObject(task, fileName)));
   }

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -32,7 +32,8 @@ function mergeDefaults (options) {
     filePaths: null,
     fs,
     prune: false,
-    s3: null
+    s3: null,
+    skip: true
   }, options);
 }
 
@@ -65,7 +66,9 @@ function upload (options) {
     .then((results) => {
       task.objects = results[0];
       task.files = results[1];
-      const plan = maps.compare(task.files, task.objects);
+      const plan = maps.compare(task.files, task.objects, {
+        skip: options.skip
+      });
       plan.noops.forEach((fileName) => task.emit('skipped', fileName));
       return uploadObjects(task, plan.uploads);
     });
@@ -73,4 +76,4 @@ function upload (options) {
   return task;
 }
 
-module.exports = { upload };
+module.exports = { mergeDefaults, upload };

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -10,6 +10,7 @@ const uploadObjects = require('./upload-object').uploadObjects;
 
 const S3_METHODS = ['listObjects', 'upload'];
 
+// assertS3 (options: Object) => Object
 function assertS3 (options) {
   const s3 = options.s3;
   if (!s3 || typeof s3 !== 'object') {
@@ -23,9 +24,11 @@ function assertS3 (options) {
   return options;
 }
 
+// mergeDefaults (options: Object) => Object
 function mergeDefaults (options) {
   options = options || {};
 
+  // create a new object, merging `options` over the top of defaults
   return Object.assign({}, {
     cwd: process.cwd(),
     dryRun: false,
@@ -37,6 +40,8 @@ function mergeDefaults (options) {
   }, options);
 }
 
+// getFilePaths (options: Object) => Promise<String[]>
+// passes the provided filePaths through, otherwise scans the filesystem
 function getFilePaths (options) {
   if (Array.isArray(options.filePaths)) {
     return Promise.resolve(options.filePaths.concat([]));
@@ -48,17 +53,26 @@ function getFilePaths (options) {
   });
 }
 
+// upload (options: UploadOptions) => Task
+// main entry point, see README.md
 function upload (options) {
   options = mergeDefaults(options);
   assertS3(options);
 
+  // make an object that inherits from EventEmitter
   const task = Object.create(EventEmitter.prototype, {});
+
+  // copy some critical options to it for later use
   task.s3 = options.s3;
   task.cwd = options.cwd;
+
+  // create a Promise, consumers can use Promise and/or events
+  // start by ensuring that we have a list of files to work on
   task.promise = getFilePaths(options)
     .then((filePaths) => {
       task.filePaths = filePaths;
     })
+    // scan remote S3 Bucket and local filesystem concurrently
     .then(() => Promise.all([
       listObjects(options.s3).then(maps.fromS3Contents),
       maps.fromFiles(null, options.cwd, task.filePaths)
@@ -66,10 +80,14 @@ function upload (options) {
     .then((results) => {
       task.objects = results[0];
       task.files = results[1];
+      // compare local and remote Maps, build a plan
       const plan = maps.compare(task.files, task.objects, {
         skip: options.skip
       });
+      // per our API, emit events for any files that we are skipping
       plan.noops.forEach((fileName) => task.emit('skipped', fileName));
+
+      // perform the work, start uploading!
       return uploadObjects(task, plan.uploads);
     });
 

--- a/lib/utils/fs-map-child.js
+++ b/lib/utils/fs-map-child.js
@@ -6,6 +6,7 @@ const path = require('path');
 const pify = require('pify');
 
 const md5stream = require('./md5').md5stream;
+const mimeType = require('./mime').mimeType;
 
 const fsp = pify(fs);
 
@@ -13,12 +14,15 @@ module.exports = function (input, callback) {
   const localPath = path.join(input.cwd, input.filePath);
   Promise.all([
     fsp.stat(localPath),
-    md5stream(fs.createReadStream(localPath))
+    md5stream(fs.createReadStream(localPath)),
+    mimeType(localPath)
   ])
     .then((results) => {
       const stats = results[0];
       const md5 = results[1];
+      const mime = results[2];
       callback(null, {
+        ContentType: mime,
         ETag: md5,
         Key: input.filePath,
         LastModified: stats.mtime,

--- a/lib/utils/fs-map-child.js
+++ b/lib/utils/fs-map-child.js
@@ -10,8 +10,10 @@ const mimeType = require('./mime').mimeType;
 
 const fsp = pify(fs);
 
+// each worker executes this function
 module.exports = function (input, callback) {
   const localPath = path.join(input.cwd, input.filePath);
+  // calculate size, MD5 and MIME all concurrently
   Promise.all([
     fsp.stat(localPath),
     md5stream(fs.createReadStream(localPath)),
@@ -21,6 +23,7 @@ module.exports = function (input, callback) {
       const stats = results[0];
       const md5 = results[1];
       const mime = results[2];
+      // return with the collected results
       callback(null, {
         ContentType: mime,
         ETag: md5,

--- a/lib/utils/mime.js
+++ b/lib/utils/mime.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const fileType = require('file-type');
+const readChunk = require('read-chunk');
+const mime = require('mime-types');
+const pify = require('pify');
+
+const readChunkp = pify(readChunk);
+
+const GENERIC_TYPES = [ 'application/octet-stream', 'text/plain' ];
+
+function fallback (magic, filePath) {
+  if (!magic || !magic.mime) {
+    return mime.lookup(filePath) || 'application/octet-stream';
+  }
+  if (GENERIC_TYPES.indexOf(magic.mime) !== -1) {
+    return mime.lookup(filePath) || magic.mime;
+  }
+  return magic.mime;
+}
+
+function mimeType (filePath) {
+  return readChunkp(filePath, 0, 262)
+    .then((buffer) => fileType(buffer))
+    .then((magic) => fallback(magic, filePath));
+}
+
+module.exports = { mimeType };

--- a/lib/utils/mime.js
+++ b/lib/utils/mime.js
@@ -7,21 +7,31 @@ const pify = require('pify');
 
 const readChunkp = pify(readChunk);
 
+// MIME types that are too vague to be useful
 const GENERIC_TYPES = [ 'application/octet-stream', 'text/plain' ];
 
+// fallback (magic?: Object, filePath: String) => String
 function fallback (magic, filePath) {
   if (!magic || !magic.mime) {
+    // first 262 bytes told us nothing
+    // detect using filename extension
     return mime.lookup(filePath) || 'application/octet-stream';
   }
   if (GENERIC_TYPES.indexOf(magic.mime) !== -1) {
+    // first 262 bytes told us nothing useful
+    // detect using filename extension
     return mime.lookup(filePath) || magic.mime;
   }
+  // use the result from the first 262 bytes
   return magic.mime;
 }
 
+// mimeType (filePath: String) => Promise<String>
 function mimeType (filePath) {
+  // detect MIME using only first 262 bytes of file
   return readChunkp(filePath, 0, 262)
     .then((buffer) => fileType(buffer))
+    // in case that failed, use the filename extension
     .then((magic) => fallback(magic, filePath));
 }
 

--- a/package.json
+++ b/package.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/blinkmobile/aws-s3.js/issues"
   },
   "dependencies": {
-    "glob": "7.0.0",
+    "glob": "7.0.3",
     "pify": "2.3.0",
     "worker-farm": "1.3.1"
   },
   "devDependencies": {
-    "ava": "^0.12.0",
+    "ava": "^0.13.0",
     "eslint": "^2.2.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-standard": "^1.3.2",
     "fixpack": "^2.3.0",
     "npm-run-all": "^1.5.1",
-    "nyc": "^5.6.0"
+    "nyc": "^6.1.1"
   },
   "engines": {
     "node": ">=4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "url": "https://github.com/blinkmobile/aws-s3.js/issues"
   },
   "dependencies": {
-    "glob": "7.0.3",
-    "pify": "2.3.0",
-    "worker-farm": "1.3.1"
+    "glob": "^7.0.3",
+    "pify": "^2.3.0",
+    "worker-farm": "^1.3.1"
   },
   "devDependencies": {
     "ava": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
     "url": "https://github.com/blinkmobile/aws-s3.js/issues"
   },
   "dependencies": {
+    "file-type": "^3.8.0",
     "glob": "^7.0.3",
+    "mime-types": "^2.1.10",
     "pify": "^2.3.0",
+    "read-chunk": "^1.0.1",
     "worker-farm": "^1.3.1"
   },
   "devDependencies": {

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const test = require('ava');
+
+const mergeDefaults = require('../lib/upload').mergeDefaults;
+
+test('mergeDefaults({}) => skip=true', (t) => {
+  const options = mergeDefaults({});
+  t.is(options.skip, true);
+});
+
+test('mergeDefaults({ skip: true }) => skip=true', (t) => {
+  const options = mergeDefaults({ skip: true });
+  t.is(options.skip, true);
+});
+
+test('mergeDefaults({ skip: false }) => skip=false', (t) => {
+  const options = mergeDefaults({ skip: false });
+  t.is(options.skip, false);
+});

--- a/test/maps.js
+++ b/test/maps.js
@@ -14,11 +14,13 @@ test('fromFiles', (t) => {
   ];
   const expected = {
     'abc.txt': {
+      ContentType: 'text/plain',
       Key: 'abc.txt',
       ETag: '6cd3556deb0da54bca060b4c39479839',
       Size: 13
     },
     'sub/sub/index.html': {
+      ContentType: 'text/html',
       Key: 'sub/sub/index.html',
       ETag: '62f9bca5a72ef519c4877c61ac2c8ac7',
       Size: 112
@@ -71,7 +73,7 @@ test('compareMaps', (t) => {
       // real ETags from S3 have double-quotes
       abc.ETag = `"${abc.ETag}"`;
       objects.set('abc.txt', abc);
-      objects.set('sub/extra.txt', {
+      objects.set('sub/extra.txt', { // new file, should upload
         Key: 'sub/extra.txt',
         ETag: '"62f9bca5a72ef519c4877c61ac2c8ac7"',
         Size: 112

--- a/test/mime.js
+++ b/test/mime.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const path = require('path');
+
+const test = require('ava');
+
+const mimeType = require('../lib/utils/mime').mimeType;
+
+const projectFiles = {
+  '.gitignore': 'application/octet-stream',
+  'CHANGELOG.md': 'text/x-markdown'
+};
+
+Object.keys(projectFiles).forEach((projectFile) => {
+  const expected = projectFiles[projectFile];
+
+  test(projectFile, (t) => {
+    return mimeType(path.join(__dirname, '..', projectFile))
+      .then((mime) => {
+        t.is(mime, expected);
+      });
+  });
+});
+
+test('missing.txt', (t) => {
+  return mimeType(path.join(__dirname, '..', 'missing.txt'))
+    .then(() => t.fail('should not resolve'))
+    .catch((err) => t.ok(err));
+});

--- a/test/upload.js
+++ b/test/upload.js
@@ -9,7 +9,13 @@ const upload = require('..').upload;
 
 const mockS3 = {
   listObjects (options, callback) { callback(null, { Contents: [] }); },
-  upload (options, callback) { callback(null); }
+  upload (options, callback) {
+    if (!options.ContentType) {
+      callback(new TypeError('missing ContentType'));
+      return;
+    }
+    callback(null);
+  }
 };
 
 test('upload() missing s3 throws', (t) => {


### PR DESCRIPTION
### Added

- CC-11: "skip" option, default to `true`, bypass content that seems to match remote already (#1, @jokeyrhyme)


### Fixed

- CC-11: detect MIME type locally, and submit as "ContentType" option during upload (#1, @jokeyrhyme)