### PR TITLE
CC-16 # --prune now removes files from S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 2.0.0 - 2016-06-08
+
+### Changed
+
+- CC-16: AWS SDK for Javascript v2.3.9 or above is required
+
+### Added
+
+- CC-16: "prune" option now removes files from the s3 bucket that are not on the local file system
+- CC-16 "deleting" and "deleted" events
+- CC-16: listObjects now supports s3 buckets with > 1000 objects
 
 ## 1.2.0 - 2016-04-04
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ npm install @blinkmobile/aws-s3 aws-sdk
 const upload = require('@blinkmobile/aws-s3').upload;
 const AWS = require('aws-sdk');
 ```
+## Requirements
 
+AWS SDK for Javascript, version >= v2.3.9
 
 ## Usage
 
@@ -78,6 +80,10 @@ interface UploadOptions {
 
 - **error**: `error`, `fileName`
 
+- **deleting**: `fileName`
+
+- **deleted**: `fileName`
+
 ```js
 const task = upload({ /* ... */ });
 task.on('error', (error, fileName) => {
@@ -89,6 +95,4 @@ task.on('error', (error, fileName) => {
 ## Roadmap
 
 - [ ] "dryRun" option
-- [ ] "prune" option
 - [ ] "fs" option
-- [ ] support S3 Buckets with more than 1000 Objects

--- a/lib/delete-objects.js
+++ b/lib/delete-objects.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const chunk = require('lodash.chunk');
+
+const deleteObjectTask = (task) => (keys) => {
+  return new Promise((resolve, reject) => {
+    keys.forEach((filename) => task.emit('deleting', filename));
+    task.s3.deleteObjects({
+      Delete: {
+        Objects: keys.map((k) => ({Key: k}))
+      }
+    }, (err, data) => {
+      if (err) {
+        return reject(err);
+      }
+
+      // let any listeners know which files have been deleted
+      if (data.Deleted.length) {
+        data.Deleted.forEach((deleted) => task.emit('deleted', deleted.Key));
+      }
+
+      // if there were any errors for single files, emit the error.
+      if (data.Errors.length) {
+        data.Errors.forEach((err) => task.emit('error', new Error(err.Message), err.Key));
+      }
+      resolve(data);
+    });
+  });
+};
+
+function deleteObjects (task, keys) {
+  // deleteObjects is limited to 1000 keys at a time
+  // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#deleteObjects-property
+
+  const chunks = chunk(keys);
+  return Promise.all(chunks.map(deleteObjectTask(task)));
+}
+
+module.exports = {deleteObjects};

--- a/lib/delete-objects.js
+++ b/lib/delete-objects.js
@@ -32,7 +32,7 @@ function deleteObjects (task, keys) {
   // deleteObjects is limited to 1000 keys at a time
   // http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#deleteObjects-property
 
-  const chunks = chunk(keys);
+  const chunks = chunk(keys, 1000);
   return Promise.all(chunks.map(deleteObjectTask(task)));
 }
 

--- a/lib/list-objects.js
+++ b/lib/list-objects.js
@@ -1,18 +1,37 @@
 'use strict';
 
-function listObjects (s3) {
+const co = require('co');
+
+const listObjects = function (s3, continuationToken) {
   return new Promise((resolve, reject) => {
-    s3.listObjects({}, function (err, data) {
+    const params = {};
+    if (continuationToken) {
+      params.ContinuationToken = continuationToken;
+    }
+    s3.listObjectsV2(params, (err, data) => {
       if (err) {
-        if (!(err instanceof Error)) {
-          err = new Error(err);
-        }
-        reject(err);
-        return;
+        return reject(err);
       }
-      resolve(data.Contents);
+
+      resolve(data);
     });
   });
-}
+};
 
-module.exports = { listObjects };
+const listAll = co.wrap(function * (s3) {
+  // wait for the first batch of objects from s3
+  let results = yield listObjects(s3);
+  let contents = results.Contents;
+
+  // if we have more results
+  while (results.NextContinuationToken) {
+    // get those results and wait for the async task to finish
+    results = yield listObjects(s3, results.NextContinuationToken);
+    // add results to the list
+    contents = contents.concat(results.Contents);
+  }
+
+  return contents;
+});
+
+module.exports = { listObjects: listAll };

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -7,8 +7,9 @@ const maps = require('./maps');
 const glob = require('./utils/glob').glob;
 const listObjects = require('./list-objects').listObjects;
 const uploadObjects = require('./upload-object').uploadObjects;
+const deleteObjects = require('./delete-objects.js').deleteObjects;
 
-const S3_METHODS = ['listObjects', 'upload'];
+const S3_METHODS = ['listObjectsV2', 'upload'];
 
 // assertS3 (options: Object) => Object
 function assertS3 (options) {
@@ -88,6 +89,13 @@ function upload (options) {
       plan.noops.forEach((fileName) => task.emit('skipped', fileName));
 
       // perform the work, start uploading!
+      if (options.prune) {
+        return Promise.all([
+          uploadObjects(task, plan.uploads),
+          deleteObjects(task, plan.deletes)
+        ]);
+      }
+
       return uploadObjects(task, plan.uploads);
     });
 

--- a/package.json
+++ b/package.json
@@ -1,27 +1,29 @@
 {
   "name": "@blinkmobile/aws-s3",
   "description": "our simplified wrapper for common AWS S3 operations",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "bugs": {
     "url": "https://github.com/blinkmobile/aws-s3.js/issues"
   },
   "dependencies": {
+    "co": "^4.6.0",
     "file-type": "^3.8.0",
     "glob": "^7.0.3",
+    "lodash.chunk": "^4.0.6",
     "mime-types": "^2.1.10",
     "pify": "^2.3.0",
     "read-chunk": "^1.0.1",
     "worker-farm": "^1.3.1"
   },
   "devDependencies": {
-    "ava": "^0.13.0",
-    "eslint": "^2.2.0",
-    "eslint-config-standard": "^5.1.0",
-    "eslint-plugin-promise": "^1.0.8",
+    "ava": "^0.15.2",
+    "eslint": "^2.11.1",
+    "eslint-config-standard": "^5.3.1",
+    "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-standard": "^1.3.2",
-    "fixpack": "^2.3.0",
-    "npm-run-all": "^1.5.1",
-    "nyc": "^6.1.1"
+    "fixpack": "^2.3.1",
+    "npm-run-all": "^2.1.1",
+    "nyc": "^6.4.4"
   },
   "engines": {
     "node": ">=4.0.0",

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -18,3 +18,13 @@ test('mergeDefaults({ skip: false }) => skip=false', (t) => {
   const options = mergeDefaults({ skip: false });
   t.is(options.skip, false);
 });
+
+test('mergeDefaults({prune: true}) => prune=true', (t) => {
+  const options = mergeDefaults({ prune: true });
+  t.is(options.prune, true);
+});
+
+test('mergeDefaults({prune: false}) => prune=false', (t) => {
+  const options = mergeDefaults({ prune: false });
+  t.is(options.prune, false);
+});

--- a/test/list-objects.js
+++ b/test/list-objects.js
@@ -4,9 +4,9 @@ const test = require('ava');
 
 const listObjects = require('../lib/list-objects').listObjects;
 
-test.cb('calls AWS.S3#listObjects()', (t) => {
+test.cb('calls AWS.S3#listObjectsV2()', (t) => {
   const mockS3 = {
-    listObjects (options, callback) {
+    listObjectsV2 (options, callback) {
       callback(null, { Contents: [] });
       t.end();
     }
@@ -14,13 +14,49 @@ test.cb('calls AWS.S3#listObjects()', (t) => {
   listObjects(mockS3);
 });
 
-test('AWS.S3#listObjects() has error', (t) => {
+test('AWS.S3#listObjectsV2() has error', (t) => {
   const mockS3 = {
-    listObjects (options, callback) {
+    listObjectsV2 (options, callback) {
       callback(new Error('boom!'));
     }
   };
   return listObjects(mockS3)
     .then(() => t.fail('resolved'))
-    .catch((err) => t.ok(err));
+    .catch((err) => t.truthy(err));
+});
+
+test('returns all results from a bucket when the server truncates the result', (t) => {
+  let i = 0;
+  const mockS3 = {
+    listObjectsV2 (options, callback) {
+      const results = {Contents: [++i]};
+      if (i < 10) {
+        results.NextContinuationToken = '1';
+      }
+
+      return callback(null, results);      
+    }
+  };
+  return listObjects(mockS3).then((results) => {
+    t.is(results.length, 10);
+    t.deepEqual(results, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+});
+
+test('fails if the server returns an error', (t) => {
+  let i = 0;
+  const mockS3 = {
+    listObjectsV2 (options, callback) {
+      const results = {Contents: [++i]};
+      if (i < 10) {
+        results.NextContinuationToken = '1';
+      }
+      if (i === 9) {
+        return callback(new Error('blah'));
+      }
+      return callback(null, results);
+    }
+  };
+
+  t.throws(listObjects(mockS3), 'blah');
 });

--- a/test/maps.js
+++ b/test/maps.js
@@ -29,9 +29,9 @@ test('fromFiles', (t) => {
   return maps.fromFiles(null, cwd, filePaths)
     .then((map) => filePaths.forEach((key) => {
       const entry = map.get(key);
-      t.ok(entry.LastModified instanceof Date);
+      t.truthy(entry.LastModified instanceof Date);
       delete entry.LastModified; // value is too unpredictable for this test
-      t.same(map.get(key), expected[key]);
+      t.deepEqual(map.get(key), expected[key]);
     }));
 });
 
@@ -42,7 +42,7 @@ test('fsFileToMap with missing local file', (t) => {
   ];
   return maps.fromFiles(null, cwd, filePaths)
     .then(() => t.fail('resolved'))
-    .catch((err) => t.ok(err));
+    .catch((err) => t.truthy(err));
 });
 
 test('s3ContentsToMap', (t) => {
@@ -56,7 +56,7 @@ test('s3ContentsToMap', (t) => {
   ];
   return maps.fromS3Contents(contents)
     .then((map) => {
-      t.same(contents[0], map.get(contents[0].Key));
+      t.deepEqual(contents[0], map.get(contents[0].Key));
     });
 });
 
@@ -80,9 +80,9 @@ test('compareMaps skip=true', (t) => {
       });
 
       const results = maps.compare(files, objects, { skip: true });
-      t.same(results.deletes, ['sub/extra.txt']);
-      t.same(results.noops, ['abc.txt']);
-      t.same(results.uploads, ['sub/sub/index.html']);
+      t.deepEqual(results.deletes, ['sub/extra.txt']);
+      t.deepEqual(results.noops, ['abc.txt']);
+      t.deepEqual(results.uploads, ['sub/sub/index.html']);
     });
 });
 
@@ -106,9 +106,9 @@ test('compareMaps skip=false', (t) => {
       });
 
       const results = maps.compare(files, objects, { skip: false });
-      t.same(results.deletes, ['sub/extra.txt']);
-      t.same(results.noops, []);
+      t.deepEqual(results.deletes, ['sub/extra.txt']);
+      t.deepEqual(results.noops, []);
       results.uploads.sort(); // need to make tests deterministic
-      t.same(results.uploads, ['abc.txt', 'sub/sub/index.html']);
+      t.deepEqual(results.uploads, ['abc.txt', 'sub/sub/index.html']);
     });
 });

--- a/test/mime.js
+++ b/test/mime.js
@@ -25,5 +25,5 @@ Object.keys(projectFiles).forEach((projectFile) => {
 test('missing.txt', (t) => {
   return mimeType(path.join(__dirname, '..', 'missing.txt'))
     .then(() => t.fail('should not resolve'))
-    .catch((err) => t.ok(err));
+    .catch((err) => t.truthy(err));
 });

--- a/test/upload.js
+++ b/test/upload.js
@@ -8,7 +8,7 @@ const test = require('ava');
 const upload = require('..').upload;
 
 const mockS3 = {
-  listObjects (options, callback) { callback(null, { Contents: [] }); },
+  listObjectsV2 (options, callback) { callback(null, { Contents: [] }); },
   upload (options, callback) {
     if (!options.ContentType) {
       callback(new TypeError('missing ContentType'));
@@ -26,14 +26,18 @@ test('upload() incomplete s3 throws', (t) => {
   t.throws(() => upload({ s3: {} }), TypeError);
 });
 
+test('upload() old s3 version throws', (t) => {
+  t.throws(() => upload({ s3: {listObjects: () => true} }), TypeError);
+});
+
 test('upload() => EventEmitter', (t) => {
   const task = upload({ s3: mockS3 });
-  t.ok(task instanceof EventEmitter);
+  t.truthy(task instanceof EventEmitter);
 });
 
 test('upload().promise: Promise', (t) => {
   const task = upload({ s3: mockS3 });
-  t.ok(task.promise instanceof global.Promise);
+  t.truthy(task.promise instanceof global.Promise);
   return task.promise;
 });
 
@@ -46,7 +50,7 @@ test('task = upload({ filePaths: [...] }); task.filePaths as provided', (t) => {
   const task = upload({ cwd, filePaths, s3: mockS3 });
   return task.promise
     .then(() => {
-      t.same(task.filePaths, filePaths);
+      t.deepEqual(task.filePaths, filePaths);
     });
 });
 
@@ -59,7 +63,7 @@ test('task = upload({ filePaths: null }); task.filePaths glob\'ed', (t) => {
   const task = upload({ cwd, s3: mockS3 });
   return task.promise
     .then(() => {
-      t.same(task.filePaths, filePaths);
+      t.deepEqual(task.filePaths, filePaths);
     });
 });
 
@@ -78,9 +82,60 @@ test('task = upload({ filePaths: null }); events', (t) => {
   });
   return task.promise
     .then(() => {
-      t.same(events, {
+      t.deepEqual(events, {
         'abc.txt': { uploading: true, uploaded: true },
         'sub/sub/index.html': { uploading: true, uploaded: true }
       });
     });
+});
+
+test('task uploads and deletes', (t) => {
+  const mockS3 = {
+    listObjectsV2 (options, callback) {
+      callback(null, { Contents: [
+        {Key: 'abcd.txt'},
+        {Key: 'efgh.txt'},
+        {Key: 'ijkl.txt'}
+      ]});
+    },
+    upload (options, callback) {
+      if (!options.ContentType) {
+        callback(new TypeError('missing ContentType'));
+        return;
+      }
+      callback(null);
+    },
+    deleteObjects (params, cb) {
+      cb(null, {
+        Deleted: [
+          {Key: 'abcd.txt'},
+          {Key: 'efgh.txt'},
+          {Key: 'ijkl.txt'}
+        ],
+        Errors: []
+      });
+    }
+  };
+
+  const events = {
+    'abcd.txt': {deleting: false, deleted: false},
+    'efgh.txt': {deleting: false, deleted: false},
+    'ijkl.txt': {deleting: false, deleted: false}
+  };
+  const cwd = path.join(__dirname, 'fixtures');
+  const task = upload({cwd, s3: mockS3, prune: true});
+  task.on('deleting', (filename) => {
+    events[filename].deleting = true;
+  });
+  task.on('deleted', (filename) => {
+    events[filename].deleted = true;
+  });
+
+  return task.promise.then(() => {
+    t.deepEqual(events, {
+      'abcd.txt': {deleting: true, deleted: true},
+      'efgh.txt': {deleting: true, deleted: true},
+      'ijkl.txt': {deleting: true, deleted: true}
+    });
+  });
 });


### PR DESCRIPTION
- Bumped version to 2.0.0 due to requiring a new version of AWS SDK
- ListObjects now handles buckets with more than 1000 keys
- --prune removes any files not in the local file system
- added 'deleted' and 'deleting' events to the task object
- added relevant tests