### PR TITLE
CC-22 # Fixed process not finishing without calling process.exit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   CC-22: process not finishing without calling process.exit()
+
 
 ## 2.1.0 - 2016-10-31
 

--- a/lib/maps.js
+++ b/lib/maps.js
@@ -25,6 +25,7 @@ function fromFiles (fs, cwd, filePaths) {
       // sends one path at a time to the worker pool
       workers({ cwd, filePath }, (err, output) => {
         if (err) {
+          workerFarm.end(workers);
           reject(err);
           return;
         }
@@ -36,6 +37,7 @@ function fromFiles (fs, cwd, filePaths) {
         // we can only tell we are finished by counting our results
         if (map.size >= filePaths.length) {
           // looks like we're done
+          workerFarm.end(workers);
           resolve(map);
         }
       });


### PR DESCRIPTION
### Fixed

-   CC-22: process not finishing without calling process.exit()
